### PR TITLE
Update setup docs

### DIFF
--- a/DOPEMUX-UBERSLICER-TFE/README.md
+++ b/DOPEMUX-UBERSLICER-TFE/README.md
@@ -10,6 +10,12 @@
 pip install -e .
 ```
 
+After installing, configure your locale so Python defaults to UTF-8:
+
+```bash
+bash scripts/setup-env.sh
+```
+
 ## File Law
 - Every run is autopatched to devlog/audit.
 - All outputs are YAML ritual blocks.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,17 @@ dopemux validate
 dopemux doctor
 ```
 
+## Setup
+
+Run the locale setup script before using Dopemux. It ensures Python sees UTF-8
+locales on macOS and Linux:
+
+```bash
+bash scripts/setup-env.sh
+```
+
+After running the script you can call the CLI commands normally.
+
 ## Layout
 
 - `uberslicer/` - core library modules


### PR DESCRIPTION
## Summary
- document running `scripts/setup-env.sh` for locale setup
- mention locale script in subproject installation steps

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68542922ced48326a1e6668f1d16f3ea