### PR TITLE
Add colorize ANSI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,8 @@ dopemux doctor
 Configure paths in `config.yaml`. Schema paths are relative so the
 project works anywhere.
 
+## Color output
+
+`utils.colorize()` wraps text with ANSI escape codes. Customize styles in
+`config.yaml` under `dopemux.colors`.
+

--- a/utils.py
+++ b/utils.py
@@ -17,15 +17,35 @@ def load_config():
     return full_cfg["dopemux"]
 
 
-def colorize(text, style):
-    """Placeholder: color your text by style."""
-    return text
+ANSI_CODES = {
+    "black": "\033[30m",
+    "red": "\033[31m",
+    "green": "\033[32m",
+    "yellow": "\033[33m",
+    "blue": "\033[34m",
+    "magenta": "\033[35m",
+    "cyan": "\033[36m",
+    "white": "\033[37m",
+    "reset": "\033[0m",
+    "bold": "\033[1m",
+}
+
+
+def colorize(text: str, style: str) -> str:
+    """Return ``text`` wrapped in ANSI codes for ``style`` if known."""
+    code = ANSI_CODES.get(style)
+    if not code:
+        return text
+    return f"{code}{text}{ANSI_CODES['reset']}"
 
 
 def print_banner(cfg):
     """If `banner` is set in config, print it once at startup."""
     banner = cfg.get("banner")
     if banner:
+        color = cfg.get("colors", {}).get("dopamine")
+        if color:
+            banner = colorize(banner, color)
         print(banner)
 
 
@@ -33,7 +53,11 @@ def dopamine_nudge(cfg):
     """Randomly emit one of the `nudges` defined in config."""
     nudges = cfg.get("nudges", [])
     if nudges:
-        print(random.choice(nudges))
+        msg = random.choice(nudges)
+        color = cfg.get("colors", {}).get("filth")
+        if color:
+            msg = colorize(msg, color)
+        print(msg)
 
 # ────────────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- implement ANSI escape sequences in `colorize`
- colorize banner and nudge output if colors configured
- document color support

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68542922343883268543a0e44150b68e